### PR TITLE
Update workflow to set custom build name

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,15 +11,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Set BUILD_NAME
+        run: echo "BUILD_NAME=$(date '+%Y-%m-%d %H:%M:%S') | ${GITHUB_REF} | ${GITHUB_SHA}" >> $GITHUB_ENV
+
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
           record: true
+          parallel: true
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           BASE_URL: ${{ secrets.BASE_URL }}
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_NAME: ${{ env.BUILD_NAME }}


### PR DESCRIPTION
This pull request includes updates to the Cypress GitHub Actions workflow to enhance the build process and improve test execution efficiency. The most important changes include setting a `BUILD_NAME` environment variable and enabling parallel execution for Cypress tests.

Enhancements to the build process:

* [`.github/workflows/cypress.yml`](diffhunk://#diff-5da9a41590fb261de0e464c95862528100c42c77dffad53b7c6de228b6afd2bdR14-R32): Added a step to set the `BUILD_NAME` environment variable with a formatted string including the date, GitHub reference, and SHA. (`[.github/workflows/cypress.ymlR14-R32](diffhunk://#diff-5da9a41590fb261de0e464c95862528100c42c77dffad53b7c6de228b6afd2bdR14-R32)`)

Improvements to test execution:

* [`.github/workflows/cypress.yml`](diffhunk://#diff-5da9a41590fb261de0e464c95862528100c42c77dffad53b7c6de228b6afd2bdR14-R32): Enabled parallel execution for Cypress tests by setting the `parallel` option to `true`. (`[.github/workflows/cypress.ymlR14-R32](diffhunk://#diff-5da9a41590fb261de0e464c95862528100c42c77dffad53b7c6de228b6afd2bdR14-R32)`)